### PR TITLE
Ported Clock.cpp to the Autopilot project

### DIFF
--- a/Autopilot/CMakeLists.txt
+++ b/Autopilot/CMakeLists.txt
@@ -16,6 +16,7 @@ add_definitions(
 include_directories(
   Inc
   ../Common/Inc
+  Libraries/Drivers/Inc
   Libraries/CMSIS/Include
   Libraries/CMSIS/Device/ST/STM32F7xx/Include
   Lib
@@ -30,8 +31,8 @@ link_directories(
 add_subdirectory(Libraries/STM32F7xx_HAL_Driver)
 add_subdirectory(Libraries/FreeRTOS)
 
-file(GLOB_RECURSE C_SOURCES ../Common/Src/*.c ../Common/Src/stm32/*.c "Src/*.c")
-file(GLOB_RECURSE CXX_SOURCES ../Common/Src/*.cpp ../Common/Src/stm32/*.cpp "Src/*.cpp")
+file(GLOB_RECURSE C_SOURCES ../Common/Src/*.c ../Common/Src/stm32/*.c "Src/*.c" Libraries/Drivers/Src/*.c)
+file(GLOB_RECURSE CXX_SOURCES ../Common/Src/*.cpp ../Common/Src/stm32/*.cpp "Src/*.cpp" Libraries/Drivers/Src/*.cpp)
 file(GLOB_RECURSE C_INC "Inc/*.h")
 file(GLOB_RECURSE CXX_INC "Inc/*.hpp")
 

--- a/Autopilot/Libraries/Drivers/Src/stm32f7/Clock.cpp
+++ b/Autopilot/Libraries/Drivers/Src/stm32f7/Clock.cpp
@@ -1,0 +1,92 @@
+#include "Clock.hpp"
+#include "Status.hpp"
+#include "stm32f7xx_hal.h"
+
+extern StatusCode get_status_code(HAL_StatusTypeDef status);
+
+StatusCode initialize_system_clock() {
+  RCC_OscInitTypeDef RCC_OscInitStruct = {0, 0, 0, 0, 0, 0, {0, 0, 0, 0, 0, 0, 0}};
+  RCC_ClkInitTypeDef RCC_ClkInitStruct = {0, 0, 0, 0, 0};
+  RCC_PeriphCLKInitTypeDef PeriphClkInitStruct =
+      {0, {0, 0, 0, 0}, {0, 0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+  /**Configure LSE Drive Capability
+  */
+  HAL_PWR_EnableBkUpAccess();
+  /**Configure the main internal regulator output voltage
+  */
+  __HAL_RCC_PWR_CLK_ENABLE();
+  __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
+  /**Initializes the CPU, AHB and APB busses clocks
+  */
+  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
+  RCC_OscInitStruct.HSEState = RCC_HSE_ON;
+  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
+  RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
+  RCC_OscInitStruct.PLL.PLLM = 4;
+  RCC_OscInitStruct.PLL.PLLN = 216;
+  RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV2;
+  RCC_OscInitStruct.PLL.PLLQ = 2;
+
+  StatusCode status = get_status_code(HAL_RCC_OscConfig(&RCC_OscInitStruct));
+  if (status != STATUS_CODE_OK) return status;
+
+  /**Activate the Over-Drive mode
+  */
+  status = get_status_code(HAL_PWREx_EnableOverDrive());
+  if (status != STATUS_CODE_OK) return status;
+
+  /**Initializes the CPU, AHB and APB busses clocks
+  */
+  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_SYSCLK
+      | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2;
+  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
+  RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
+  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV4;
+  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV2;
+
+  status = get_status_code(HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_7));
+  if (status != STATUS_CODE_OK) return status;
+
+  PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_USART1 | RCC_PERIPHCLK_USART2
+      | RCC_PERIPHCLK_USART3 | RCC_PERIPHCLK_UART4
+      | RCC_PERIPHCLK_I2C1 | RCC_PERIPHCLK_I2C2
+      | RCC_PERIPHCLK_I2C4;
+  PeriphClkInitStruct.Usart1ClockSelection = RCC_USART1CLKSOURCE_PCLK2;
+  PeriphClkInitStruct.Usart2ClockSelection = RCC_USART2CLKSOURCE_PCLK1;
+  PeriphClkInitStruct.Usart3ClockSelection = RCC_USART3CLKSOURCE_PCLK1;
+  PeriphClkInitStruct.Uart4ClockSelection = RCC_UART4CLKSOURCE_PCLK1;
+  PeriphClkInitStruct.I2c1ClockSelection = RCC_I2C1CLKSOURCE_PCLK1;
+  PeriphClkInitStruct.I2c2ClockSelection = RCC_I2C2CLKSOURCE_PCLK1;
+  PeriphClkInitStruct.I2c4ClockSelection = RCC_I2C4CLKSOURCE_PCLK1;
+
+  status = get_status_code(HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct));
+  if (status != STATUS_CODE_OK) return status;
+
+  return STATUS_CODE_OK;
+}
+
+uint32_t get_lsi_clock() {
+  return 32000UL; //32khz lsi clock on stm32f7
+}
+
+uint64_t get_system_time_us() {
+  return (uint64_t) (HAL_GetTick() * 1000ULL + TIM4->CNT / (get_system_clock() / 1000000UL));
+}
+
+/**
+ *  Since the SysTick handler is overwridden by FreeRTOS, we use Timer4 as our system time
+ *  This callback is the equivalent of the systick callback
+  * @brief  Period elapsed callback in non blocking mode
+  * @note   This function is called  when TIM4 interrupt took place, inside
+  * HAL_TIM_IRQHandler(). It makes a direct call to HAL_IncTick() to increment
+  * a global variable "uwTick" used as application time base.
+  * @param  htim : TIM handle
+  * @retval None
+  */
+void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
+{
+  if (htim->Instance == TIM4) {
+    HAL_IncTick();
+  }
+}

--- a/Autopilot/Libraries/Drivers/Src/stm32f7/SPI.cpp
+++ b/Autopilot/Libraries/Drivers/Src/stm32f7/SPI.cpp
@@ -1,8 +1,8 @@
-#include "../../../../Common/Inc/Status.hpp"
-#include "stm32f0xx_hal.h"
-#include "../../../../Common/Inc/SPI.hpp"
-#include "../../../../Common/Inc/GPIO.hpp"
-#include "../../../../Common/Inc/Clock.hpp"
+#include "Status.hpp"
+#include "stm32f7xx_hal.h"
+#include "SPI.hpp"
+#include "GPIO.hpp"
+#include "Clock.hpp"
 
 const uint32_t SPI_SYNCHRONOUS_TIMEOUT = 50; //50ms timeout for synchronous implementation
 
@@ -26,81 +26,81 @@ SPIPort::SPIPort(SPISettings settings) {
 }
 
 StatusCode SPIPort::setup() {
-	if (has_setup) { //if the interface was already setup
-		return STATUS_CODE_INVALID_ARGS;
-	}
-	if (settings.word_size != 1 || settings.word_size != 2) { //we only support 8-bit or 16-bit spi
-		return STATUS_CODE_INVALID_ARGS;
-	}
-
-	if (settings.port == SPI_PORT1) { //only port 1 valid for stm32f0
-		hspi1.Instance = SPI1;
-
-		StatusCode status;
-
-		__HAL_RCC_SPI1_CLK_ENABLE();
-
-		//spi1 is on apb1 bus for spi1
-		uint32_t clock = get_peripheral_clock_apb1();
-
-		//only configure nss in case we're in slave mode
-		if (!settings.master) {
-			nss = GPIOPin(NSS_PORT_SPI1,
-						  NSS_PIN_SPI1,
-						  GPIO_ALT_PP,
-						  GPIO_STATE_LOW,
-						  GPIO_RES_NONE,
-						  GPIO_SPEED_HIGH,
-						  GPIO_AF0_SPI1);
-			status = nss.setup();
-			if (status != STATUS_CODE_OK) {
-				return status;
-			}
-		}
-
-		miso = GPIOPin(MISO_PORT_SPI1,
-					   MISO_PIN_SPI1,
-					   GPIO_ALT_PP,
-					   GPIO_STATE_LOW,
-					   GPIO_RES_NONE,
-					   GPIO_SPEED_HIGH,
-					   GPIO_AF0_SPI1);
-		mosi = GPIOPin(MOSI_PORT_SPI1,
-					   MOSI_PIN_SPI1,
-					   GPIO_ALT_PP,
-					   GPIO_STATE_LOW,
-					   GPIO_RES_NONE,
-					   GPIO_SPEED_HIGH,
-					   GPIO_AF0_SPI1);
-		sck = GPIOPin(SCK_PORT_SPI1,
-					  SCK_PIN_SPI1,
-					  GPIO_ALT_PP,
-					  GPIO_STATE_LOW,
-					  GPIO_RES_NONE,
-					  GPIO_SPEED_HIGH,
-					  GPIO_AF0_SPI1);
-
-		status = miso.setup();
-		if (status != STATUS_CODE_OK) {
-			return status;
-		}
-		status = mosi.setup();
-		if (status != STATUS_CODE_OK) {
-			return status;
-		}
-		status = sck.setup();
-		if (status != STATUS_CODE_OK) {
-			return status;
-		}
-
-		status = configure_spi_port(&hspi1, this->settings, clock);
-
-		//configure SPI1 interrupts
-		HAL_NVIC_SetPriority(SPI1_IRQn, 0, 0);
-		HAL_NVIC_EnableIRQ(SPI1_IRQn);
-
-		return status;
-	}
+//	if (has_setup) { //if the interface was already setup
+//		return STATUS_CODE_INVALID_ARGS;
+//	}
+//	if (settings.word_size != 1 || settings.word_size != 2) { //we only support 8-bit or 16-bit spi
+//		return STATUS_CODE_INVALID_ARGS;
+//	}
+//
+//	if (settings.port == SPI_PORT1) { //only port 1 valid for stm32f0
+//		hspi1.Instance = SPI1;
+//
+//		StatusCode status;
+//
+//		__HAL_RCC_SPI1_CLK_ENABLE();
+//
+//		//spi1 is on apb1 bus for spi1
+//		uint32_t clock = get_peripheral_clock_apb1();
+//
+//		//only configure nss in case we're in slave mode
+//		if (!settings.master) {
+//			nss = GPIOPin(NSS_PORT_SPI1,
+//						  NSS_PIN_SPI1,
+//						  GPIO_ALT_PP,
+//						  GPIO_STATE_LOW,
+//						  GPIO_RES_NONE,
+//						  GPIO_SPEED_HIGH,
+//						  GPIO_AF0_SPI1);
+//			status = nss.setup();
+//			if (status != STATUS_CODE_OK) {
+//				return status;
+//			}
+//		}
+//
+//		miso = GPIOPin(MISO_PORT_SPI1,
+//					   MISO_PIN_SPI1,
+//					   GPIO_ALT_PP,
+//					   GPIO_STATE_LOW,
+//					   GPIO_RES_NONE,
+//					   GPIO_SPEED_HIGH,
+//					   GPIO_AF0_SPI1);
+//		mosi = GPIOPin(MOSI_PORT_SPI1,
+//					   MOSI_PIN_SPI1,
+//					   GPIO_ALT_PP,
+//					   GPIO_STATE_LOW,
+//					   GPIO_RES_NONE,
+//					   GPIO_SPEED_HIGH,
+//					   GPIO_AF0_SPI1);
+//		sck = GPIOPin(SCK_PORT_SPI1,
+//					  SCK_PIN_SPI1,
+//					  GPIO_ALT_PP,
+//					  GPIO_STATE_LOW,
+//					  GPIO_RES_NONE,
+//					  GPIO_SPEED_HIGH,
+//					  GPIO_AF0_SPI1);
+//
+//		status = miso.setup();
+//		if (status != STATUS_CODE_OK) {
+//			return status;
+//		}
+//		status = mosi.setup();
+//		if (status != STATUS_CODE_OK) {
+//			return status;
+//		}
+//		status = sck.setup();
+//		if (status != STATUS_CODE_OK) {
+//			return status;
+//		}
+//
+//		status = configure_spi_port(&hspi1, this->settings, clock);
+//
+//		//configure SPI1 interrupts
+//		HAL_NVIC_SetPriority(SPI1_IRQn, 0, 0);
+//		HAL_NVIC_EnableIRQ(SPI1_IRQn);
+//
+//		return status;
+//	}
 	return STATUS_CODE_INVALID_ARGS;
 }
 

--- a/Autopilot/Src/main.cpp
+++ b/Autopilot/Src/main.cpp
@@ -1,53 +1,4 @@
-/**
-  ******************************************************************************
-  * @file           : main.c
-  * @brief          : Main program body
-  ******************************************************************************
-  * This notice applies to any and all portions of this file
-  * that are not between comment pairs USER CODE BEGIN and
-  * USER CODE END. Other portions of this file, whether
-  * inserted by the user or by software development tools
-  * are owned by their respective copyright owners.
-  *
-  * Copyright (c) 2019 STMicroelectronics International N.V.
-  * All rights reserved.
-  *
-  * Redistribution and use in source and binary forms, with or without
-  * modification, are permitted, provided that the following conditions are met:
-  *
-  * 1. Redistribution of source code must retain the above copyright notice,
-  *    this list of conditions and the following disclaimer.
-  * 2. Redistributions in binary form must reproduce the above copyright notice,
-  *    this list of conditions and the following disclaimer in the documentation
-  *    and/or other materials provided with the distribution.
-  * 3. Neither the name of STMicroelectronics nor the names of other
-  *    contributors to this software may be used to endorse or promote products
-  *    derived from this software without specific written permission.
-  * 4. This software, including modifications and/or derivative works of this
-  *    software, must execute solely and exclusively on microcontroller or
-  *    microprocessor devices manufactured by or for STMicroelectronics.
-  * 5. Redistribution and use of this software other than as permitted under
-  *    this license is void and will automatically terminate your rights under
-  *    this license.
-  *
-  * THIS SOFTWARE IS PROVIDED BY STMICROELECTRONICS AND CONTRIBUTORS "AS IS"
-  * AND ANY EXPRESS, IMPLIED OR STATUTORY WARRANTIES, INCLUDING, BUT NOT
-  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-  * PARTICULAR PURPOSE AND NON-INFRINGEMENT OF THIRD PARTY INTELLECTUAL PROPERTY
-  * RIGHTS ARE DISCLAIMED TO THE FULLEST EXTENT PERMITTED BY LAW. IN NO EVENT
-  * SHALL STMICROELECTRONICS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-  * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-  * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
-  * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-  * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
-  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-  *
-  ******************************************************************************
-  */
-/* USER CODE END Header */
-
-/* Includes ------------------------------------------------------------------*/
+#include "Clock.hpp"
 #include "main.h"
 #include "cmsis_os.h"
 #include "adc.h"
@@ -58,68 +9,18 @@
 #include "usart.h"
 #include "wwdg.h"
 #include "gpio.h"
-
-/* Private includes ----------------------------------------------------------*/
-/* USER CODE BEGIN Includes */
 #include "debug.h"
 #include "eeprom.h"
-/* USER CODE END Includes */
+#include <stdio.h>
 
-/* Private typedef -----------------------------------------------------------*/
-/* USER CODE BEGIN PTD */
-
-/* USER CODE END PTD */
-
-/* Private define ------------------------------------------------------------*/
-/* USER CODE BEGIN PD */
-
-/* USER CODE END PD */
-
-/* Private macro -------------------------------------------------------------*/
-/* USER CODE BEGIN PM */
-
-/* USER CODE END PM */
-
-/* Private variables ---------------------------------------------------------*/
-
-/* USER CODE BEGIN PV */
-
-/* USER CODE END PV */
-
-/* Private function prototypes -----------------------------------------------*/
-void SystemClock_Config(void);
 extern "C" void MX_FREERTOS_Init(void);
 
-/* USER CODE BEGIN PFP */
-
-/* USER CODE END PFP */
-
-/* Private user code ---------------------------------------------------------*/
-/* USER CODE BEGIN 0 */
-
-/* USER CODE END 0 */
-
-/**
-  * @brief  The application entry point.
-  * @retval int
-  */
 int main(void)
 {
-  /* USER CODE BEGIN 1 */
 
-  /* USER CODE END 1 */
-
-  /* MCU Configuration--------------------------------------------------------*/
-
-  /* Reset of all peripherals, Initializes the Flash interface and the Systick. */
   HAL_Init();
 
-  /* USER CODE BEGIN Init */
-
-  /* USER CODE END Init */
-
-  /* Configure the system clock */
-  SystemClock_Config();
+  initialize_system_clock();
 
   /* USER CODE BEGIN SysInit */
 
@@ -141,7 +42,7 @@ int main(void)
   MX_SPI2_Init();
   MX_TIM10_Init();
   MX_TIM11_Init();
-  MX_WWDG_Init();
+//  MX_WWDG_Init();
   MX_CRC_Init();
   MX_I2C2_Init();
   /* USER CODE BEGIN 2 */
@@ -158,14 +59,21 @@ int main(void)
   MX_FREERTOS_Init();
 
   /* Start scheduler */
-  osKernelStart();
+//  osKernelStart();
 
   /* We should never get here as control is now taken by the scheduler */
 
   /* Infinite loop */
   /* USER CODE BEGIN WHILE */
+  uint64_t time;
+  char buffer[100];
   while (1)
   {
+    time = get_system_time_us();
+    debug("Sys Time: %lu", (uint32_t)time);
+
+    delay(1000);
+
     /* USER CODE END WHILE */
 
     /* USER CODE BEGIN 3 */
@@ -173,98 +81,12 @@ int main(void)
   /* USER CODE END 3 */
 }
 
-/**
-  * @brief System Clock Configuration
-  * @retval None
-  */
-
-void SystemClock_Config(void)
-{
-  RCC_OscInitTypeDef RCC_OscInitStruct = {0,0,0,0,0,0,{0,0,0,0,0,0,0}};
-  RCC_ClkInitTypeDef RCC_ClkInitStruct = {0,0,0,0,0};
-  RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = {0,{0,0,0,0},{0,0,0,0},0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
-
-  /**Configure LSE Drive Capability
-  */
-  HAL_PWR_EnableBkUpAccess();
-  /**Configure the main internal regulator output voltage
-  */
-  __HAL_RCC_PWR_CLK_ENABLE();
-  __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
-  /**Initializes the CPU, AHB and APB busses clocks
-  */
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
-  RCC_OscInitStruct.HSEState = RCC_HSE_ON;
-  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
-  RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
-  RCC_OscInitStruct.PLL.PLLM = 4;
-  RCC_OscInitStruct.PLL.PLLN = 216;
-  RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV2;
-  RCC_OscInitStruct.PLL.PLLQ = 2;
-  if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /**Activate the Over-Drive mode
-  */
-  if (HAL_PWREx_EnableOverDrive() != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /**Initializes the CPU, AHB and APB busses clocks
-  */
-  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK|RCC_CLOCKTYPE_SYSCLK
-                                |RCC_CLOCKTYPE_PCLK1|RCC_CLOCKTYPE_PCLK2;
-  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
-  RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
-  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV4;
-  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV2;
-
-  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_7) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_USART1|RCC_PERIPHCLK_USART2
-                                             |RCC_PERIPHCLK_USART3|RCC_PERIPHCLK_UART4
-                                             |RCC_PERIPHCLK_I2C1|RCC_PERIPHCLK_I2C2
-                                             |RCC_PERIPHCLK_I2C4;
-  PeriphClkInitStruct.Usart1ClockSelection = RCC_USART1CLKSOURCE_PCLK2;
-  PeriphClkInitStruct.Usart2ClockSelection = RCC_USART2CLKSOURCE_PCLK1;
-  PeriphClkInitStruct.Usart3ClockSelection = RCC_USART3CLKSOURCE_PCLK1;
-  PeriphClkInitStruct.Uart4ClockSelection = RCC_UART4CLKSOURCE_PCLK1;
-  PeriphClkInitStruct.I2c1ClockSelection = RCC_I2C1CLKSOURCE_PCLK1;
-  PeriphClkInitStruct.I2c2ClockSelection = RCC_I2C2CLKSOURCE_PCLK1;
-  PeriphClkInitStruct.I2c4ClockSelection = RCC_I2C4CLKSOURCE_PCLK1;
-  if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK)
-  {
-    Error_Handler();
-  }
-}
 
 /* USER CODE BEGIN 4 */
 
 /* USER CODE END 4 */
 
-/**
-  * @brief  Period elapsed callback in non blocking mode
-  * @note   This function is called  when TIM4 interrupt took place, inside
-  * HAL_TIM_IRQHandler(). It makes a direct call to HAL_IncTick() to increment
-  * a global variable "uwTick" used as application time base.
-  * @param  htim : TIM handle
-  * @retval None
-  */
-void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
-{
-  /* USER CODE BEGIN Callback 0 */
 
-  /* USER CODE END Callback 0 */
-  if (htim->Instance == TIM4) {
-    HAL_IncTick();
-  }
-  /* USER CODE BEGIN Callback 1 */
-
-  /* USER CODE END Callback 1 */
-}
 
 /**
   * @brief  This function is executed in case of error occurrence.

--- a/Common/Src/stm32/Clock.cpp
+++ b/Common/Src/stm32/Clock.cpp
@@ -25,10 +25,6 @@ uint32_t get_system_time() {
 	return HAL_GetTick();
 }
 
-uint64_t get_system_time_us() {
-	return (uint64_t) (HAL_GetTick() * 1000ULL + SysTick->VAL / (get_system_clock() / 1000000UL));
-}
-
 void delay(uint32_t ms) {
 	HAL_Delay(ms);
 }

--- a/Safety/Libraries/Drivers/Src/stm32f0/Clock.cpp
+++ b/Safety/Libraries/Drivers/Src/stm32f0/Clock.cpp
@@ -1,5 +1,6 @@
 #include "stm32f0xx_hal.h"
 #include "Status.hpp"
+#include "Clock.hpp"
 
 extern StatusCode get_status_code(HAL_StatusTypeDef status);
 
@@ -56,4 +57,8 @@ StatusCode initialize_system_clock() {
 	HAL_RCC_MCOConfig(RCC_MCO, RCC_MCO1SOURCE_SYSCLK, RCC_MCODIV_1);
 
 	return STATUS_CODE_OK;
+}
+
+uint64_t get_system_time_us() {
+	return (uint64_t) (HAL_GetTick() * 1000ULL + SysTick->VAL / (get_system_clock() / 1000000UL));
 }


### PR DESCRIPTION
The autopilot clocks work a little different compared to the safety chip. With the inclusion of FreeRTOS on Autopilot, the Systick_Handler() function is overridden, and the generated code actually uses Timer4 for the system time base (the 1ms clock base). 

Changes
- Implemented Clock.cpp missing functionality into the autopilot project, using Timer4
- Including the Libraries/Drivers folder for building in the project
- Cleaned up main.cpp getting rid of the redundant comments...