### PR TITLE
Safety/Inc/main.hpp no longer uses a symbolic link to include GPIO.hpp

### DIFF
--- a/Safety/Inc/main.hpp
+++ b/Safety/Inc/main.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../Common/Inc/GPIO.hpp"
+#include "../../Common/Inc/GPIO.hpp"
 
 const GPIOPort LED1_GPIO_PORT = GPIO_PORT_C;
 const GPIOPinNum LED1_GPIO_PIN = 10;


### PR DESCRIPTION
Previous to this change, Safety/Inc/main.hpp included
../Common/Inc/GPIO.hpp. However, GPIO.hpp is actually present at
../../Common/Inc/GPIO.hpp. Somehow, Cmake still got things to work by
creating a symbolic link to the file.

With this change, that symbolic link was removed, which both
simplifies things and prevents some errors from occurring when running
travis-ci on windows.