### PR TITLE
OutputMixing module implementation (and also SendToActuators interface renaming)

### DIFF
--- a/Autopilot/AttitudeManager/AttitudeDatatypes.hpp
+++ b/Autopilot/AttitudeManager/AttitudeDatatypes.hpp
@@ -11,4 +11,9 @@ typedef struct
 
 }PID_Output_t;
 
+#define L_TAIL_OUT_CHANNEL 0 // Spike has ruddervators
+#define R_TAIL_OUT_CHANNEL 1
+#define AILERON_OUT_CHANNEL 2
+#define THROTTLE_OUT_CHANNEL 3
+
 #endif

--- a/Autopilot/AttitudeManager/OutputMixing.cpp
+++ b/Autopilot/AttitudeManager/OutputMixing.cpp
@@ -1,0 +1,81 @@
+#include "OutputMixing.hpp"
+
+/***********************************************************************************************************************
+ * Definitions
+ **********************************************************************************************************************/
+
+#define ADVERSE_YAW_MIX 0.5f // This value was taken from picPilot, it might need tuning.
+
+#define RUDDER_PROPORTION 0.75f // has to do with the angle of the inverse V tail, 0.75 means spike's tail is at 45 degrees.
+#define ELEVATOR_PROPORTION 0.75f
+
+/***********************************************************************************************************************
+ * Prototypes
+ **********************************************************************************************************************/
+
+static int checkInputValidity(PID_Output_t *PidOutput);
+static void constrainOutput(float *channelOut);
+
+/***********************************************************************************************************************
+ * Code
+ **********************************************************************************************************************/
+
+// TODO: What about flaps ?
+
+OutputMixing_error_t OutputMixing_Execute(PID_Output_t *PidOutput, float *channelOut)
+{
+
+#if TAIL_TYPE != INV_V_TAIL
+	#error "Requested tailtype not supported !"
+#endif
+
+	OutputMixing_error_t error;
+	error.errorCode = checkInputValidity(PidOutput);
+
+    PidOutput->yawPercent += PidOutput->rollPercent * ADVERSE_YAW_MIX; // mix roll rate into rudder to counter adverse yaw
+
+    channelOut[L_TAIL_OUT_CHANNEL] =  (PidOutput->yawPercent * RUDDER_PROPORTION) - (PidOutput->pitchPercent * ELEVATOR_PROPORTION); //Tail Output Left
+    channelOut[R_TAIL_OUT_CHANNEL] =  (PidOutput->yawPercent * RUDDER_PROPORTION) + (PidOutput->pitchPercent * ELEVATOR_PROPORTION); //Tail Output Right
+
+    channelOut[AILERON_OUT_CHANNEL] = PidOutput->rollPercent;
+    channelOut[THROTTLE_OUT_CHANNEL] = PidOutput->throttlePercent;
+
+    constrainOutput(channelOut);
+
+	return error;
+}
+
+static int checkInputValidity(PID_Output_t *PidOutput)
+{
+	int errorCode;
+
+	if ( (PidOutput->rollPercent < -100.0f) || (PidOutput->pitchPercent < -100.0f) || (PidOutput->yawPercent < -100.0f) || (PidOutput->throttlePercent < 0.0f) )
+	{
+		errorCode = 1;
+	}
+	else if ( (PidOutput->rollPercent > 100.0f) || (PidOutput->pitchPercent > 100.0f) || (PidOutput->yawPercent > 100.0f) || (PidOutput->throttlePercent > 100.0f) )
+	{
+		errorCode = 2;
+	}
+	else
+	{
+		errorCode = 0;
+	}
+
+	return errorCode;
+}
+
+static void constrainOutput(float *channelOut)
+{
+	for (int i = 0; i < 4; i++)
+	{
+		if (channelOut[i] < -100.0f)
+		{
+			channelOut[i] = -100.0f;
+		}
+		else if (channelOut[i] > 100.0f)
+		{
+			channelOut[i] = 100.0f;
+		}
+	}
+}

--- a/Autopilot/AttitudeManager/SendInstructionsToSafety.hpp
+++ b/Autopilot/AttitudeManager/SendInstructionsToSafety.hpp
@@ -1,11 +1,11 @@
 /**
- * Functions for communicating data to servos, motors
- * and other actuators over PWM
+ * Functions for communicating actuator commands to the safety chip,
+ * which in turn, sends the data out to the actuators.
  * Author: Anthony Berbari
  */
 
-#ifndef SEND_TO_ACTUATORS_HPP
-#define	SEND_TO_ACTUATORS_HPP
+#ifndef SEND_INSTRUCTIONS_TO_SAFETY_HPP
+#define	SEND_INSTRUCTIONS_TO_SAFETY_HPP
 
 /***********************************************************************************************************************
  * Definitions
@@ -13,26 +13,27 @@
 
 typedef struct
 {
-	int errorCode;
+	int errorCode; // 0 if all is successfull. Other values correspond to various errors which are tbd.
 
-}SendToActuators_error_t;
+}SendToSafety_error_t;
 
 /***********************************************************************************************************************
  * Prototypes
  **********************************************************************************************************************/
 
 /**
-* Initialises internal parameters and sets all actuator channels to their default safe settings.
+* Initialises internal parameters and instructs the safety to set all actuator channels to their default safe settings.
 * Should be called exactly once before anything is attempted to be done with the module.
 */
-void SendToActuators_Init(void);
+void SendToSafety_Init(void);
 
 /**
-* Communicates the desired actuator commands encoded in the channelOut array over PWM to
-* the appropriate actuator channels.
+* Communicates the desired actuator commands encoded in the channelOut array over I2C to
+* the safety chip. Internally, this function performs a conversion from percentages to pwm values.
+* This function is non blocking and returns right away.
 * @param[in]		channelOut 		the array (size of 4 floats) of percentages each channel should be set to.
 * @return							the error struct, containing all info about any errors that may have occured.
 */
-SendToActuators_error_t SendToActuators_Execute(float *channelOut);
+SendToSafety_error_t SendToSafety_Execute(float *channelOut);
 
 #endif

--- a/Autopilot/Test/Src/Test_AttitudeManager_OutputMixing.cpp
+++ b/Autopilot/Test/Src/Test_AttitudeManager_OutputMixing.cpp
@@ -1,0 +1,275 @@
+#include <gtest/gtest.h>
+#include "fff.h"
+
+#include "OutputMixing.hpp"
+
+using namespace std;
+using ::testing::Test;
+
+/***********************************************************************************************************************
+ * Mocks
+ **********************************************************************************************************************/
+
+/***********************************************************************************************************************
+ * Variables
+ **********************************************************************************************************************/
+
+/***********************************************************************************************************************
+ * Tests
+ **********************************************************************************************************************/
+
+TEST(AttitudeManager_OutputMixing, UnderNegative100RollReturnsError1) {
+
+   	/***********************SETUP***********************/
+
+	PID_Output_t NegativePid;
+	NegativePid.rollPercent = -101.0f;
+	NegativePid.pitchPercent = 10.0f;
+	NegativePid.yawPercent = 10.0f;
+	NegativePid.throttlePercent = 10.0f;
+
+	OutputMixing_error_t error;
+
+	float dummyMixedOutput[4]; // the prefix "dummy" indicates this variable needs to be here for things to work but has nothing to do with this test.
+
+
+	/********************DEPENDENCIES*******************/
+	/********************STEPTHROUGH********************/
+
+	error = OutputMixing_Execute(&NegativePid, dummyMixedOutput);
+
+	/**********************ASSERTS**********************/
+
+	ASSERT_EQ(error.errorCode, 1);
+}
+
+TEST(AttitudeManager_OutputMixing, UnderNegative100PitchReturnsError1) {
+
+   	/***********************SETUP***********************/
+
+	PID_Output_t NegativePid;
+	NegativePid.rollPercent = 10.0f;
+	NegativePid.pitchPercent = -101.0f;
+	NegativePid.yawPercent = 10.0f;
+	NegativePid.throttlePercent = 10.0f;
+
+	OutputMixing_error_t error;
+
+	float dummyMixedOutput[4];
+
+
+	/********************DEPENDENCIES*******************/
+	/********************STEPTHROUGH********************/
+
+	error = OutputMixing_Execute(&NegativePid, dummyMixedOutput);
+
+	/**********************ASSERTS**********************/
+
+	ASSERT_EQ(error.errorCode, 1);
+}
+
+TEST(AttitudeManager_OutputMixing, UnderNegative100YawReturnsError1) {
+
+   	/***********************SETUP***********************/
+
+	PID_Output_t NegativePid;
+	NegativePid.rollPercent = 10.0f;
+	NegativePid.pitchPercent = 10.0f;
+	NegativePid.yawPercent = -101.0f;
+	NegativePid.throttlePercent = 10.0f;
+
+	OutputMixing_error_t error;
+
+	float dummyMixedOutput[4];
+
+
+	/********************DEPENDENCIES*******************/
+	/********************STEPTHROUGH********************/
+
+	error = OutputMixing_Execute(&NegativePid, dummyMixedOutput);
+
+	/**********************ASSERTS**********************/
+
+	ASSERT_EQ(error.errorCode, 1);
+}
+
+TEST(AttitudeManager_OutputMixing, NegativeThrottleReturnsError1) {
+
+   	/***********************SETUP***********************/
+
+	PID_Output_t NegativePid;
+	NegativePid.rollPercent = 10.0f;
+	NegativePid.pitchPercent = 10.0f;
+	NegativePid.yawPercent = 10.0f;
+	NegativePid.throttlePercent = -5.0f;
+
+	OutputMixing_error_t error;
+
+	float dummyMixedOutput[4];
+
+
+	/********************DEPENDENCIES*******************/
+	/********************STEPTHROUGH********************/
+
+	error = OutputMixing_Execute(&NegativePid, dummyMixedOutput);
+
+	/**********************ASSERTS**********************/
+
+	ASSERT_EQ(error.errorCode, 1);
+}
+
+TEST(AttitudeManager_OutputMixing, Over100RollReturnsError2) {
+
+   	/***********************SETUP***********************/
+
+	PID_Output_t Over100Pid;
+	Over100Pid.rollPercent = 101.0f;
+	Over100Pid.pitchPercent = 10.0f;
+	Over100Pid.yawPercent = 10.0f;
+	Over100Pid.throttlePercent = 10.0f;
+
+	OutputMixing_error_t error;
+
+	float dummyMixedOutput[4];
+
+
+	/********************DEPENDENCIES*******************/
+	/********************STEPTHROUGH********************/
+
+	error = OutputMixing_Execute(&Over100Pid, dummyMixedOutput);
+
+	/**********************ASSERTS**********************/
+
+	ASSERT_EQ(error.errorCode, 2);
+}
+
+TEST(AttitudeManager_OutputMixing, Over100PitchReturnsError2) {
+
+   	/***********************SETUP***********************/
+
+	PID_Output_t Over100Pid;
+	Over100Pid.rollPercent = 10.0f;
+	Over100Pid.pitchPercent = 101.0f;
+	Over100Pid.yawPercent = 10.0f;
+	Over100Pid.throttlePercent = 10.0f;
+
+	OutputMixing_error_t error;
+
+	float dummyMixedOutput[4];
+
+
+	/********************DEPENDENCIES*******************/
+	/********************STEPTHROUGH********************/
+
+	error = OutputMixing_Execute(&Over100Pid, dummyMixedOutput);
+
+	/**********************ASSERTS**********************/
+
+	ASSERT_EQ(error.errorCode, 2);
+}
+
+TEST(AttitudeManager_OutputMixing, Over100YawReturnsError2) {
+
+   	/***********************SETUP***********************/
+
+	PID_Output_t Over100Pid;
+	Over100Pid.rollPercent = 10.0f;
+	Over100Pid.pitchPercent = 10.0f;
+	Over100Pid.yawPercent = 101.0f;
+	Over100Pid.throttlePercent = 10.0f;
+
+	OutputMixing_error_t error;
+
+	float dummyMixedOutput[4];
+
+
+	/********************DEPENDENCIES*******************/
+	/********************STEPTHROUGH********************/
+
+	error = OutputMixing_Execute(&Over100Pid, dummyMixedOutput);
+
+	/**********************ASSERTS**********************/
+
+	ASSERT_EQ(error.errorCode, 2);
+}
+
+TEST(AttitudeManager_OutputMixing, Over100ThrottleReturnsError2) {
+
+   	/***********************SETUP***********************/
+
+	PID_Output_t Over100Pid;
+	Over100Pid.rollPercent = 10.0f;
+	Over100Pid.pitchPercent = 10.0f;
+	Over100Pid.yawPercent = 10.0f;
+	Over100Pid.throttlePercent = 101.0f;
+
+	OutputMixing_error_t error;
+
+	float dummyMixedOutput[4];
+
+
+	/********************DEPENDENCIES*******************/
+	/********************STEPTHROUGH********************/
+
+	error = OutputMixing_Execute(&Over100Pid, dummyMixedOutput);
+
+	/**********************ASSERTS**********************/
+
+	ASSERT_EQ(error.errorCode, 2);
+}
+
+TEST(AttitudeManager_OutputMixing, AllInputValidReturnsError0) {
+
+   	/***********************SETUP***********************/
+
+	PID_Output_t Over100Pid;
+	Over100Pid.rollPercent = -10.0f;
+	Over100Pid.pitchPercent = 10.0f;
+	Over100Pid.yawPercent = 0.0f;
+	Over100Pid.throttlePercent = 10.0f;
+
+	OutputMixing_error_t error;
+
+	float dummyMixedOutput[4];
+
+
+	/********************DEPENDENCIES*******************/
+	/********************STEPTHROUGH********************/
+
+	error = OutputMixing_Execute(&Over100Pid, dummyMixedOutput);
+
+	/**********************ASSERTS**********************/
+
+	ASSERT_EQ(error.errorCode, 0);
+}
+
+TEST(AttitudeManager_OutputMixing, CannotReturnOutOfRangeValuesWhenGivenValidInput) {
+
+   	/***********************SETUP***********************/
+
+	PID_Output_t MaxVals;
+	MaxVals.rollPercent = 100.0f;
+	MaxVals.pitchPercent = 100.0f;
+	MaxVals.yawPercent = 100.0f;
+	MaxVals.throttlePercent = 100.0f;
+
+	OutputMixing_error_t error;
+
+	float mixedOutput[4];
+
+
+	/********************DEPENDENCIES*******************/
+	/********************STEPTHROUGH********************/
+
+	error = OutputMixing_Execute(&MaxVals, mixedOutput);
+
+	/**********************ASSERTS**********************/
+
+	ASSERT_EQ(error.errorCode, 0);
+
+	ASSERT_TRUE( (mixedOutput[L_TAIL_OUT_CHANNEL] <= 100.0f ) && (mixedOutput[L_TAIL_OUT_CHANNEL] >= -100.0f ) );
+	ASSERT_TRUE( (mixedOutput[R_TAIL_OUT_CHANNEL] <= 100.0f ) && (mixedOutput[R_TAIL_OUT_CHANNEL] >= -100.0f ) );
+	ASSERT_TRUE( (mixedOutput[AILERON_OUT_CHANNEL] <= 100.0f ) && (mixedOutput[AILERON_OUT_CHANNEL] >= -100.0f ) );
+	ASSERT_TRUE( (mixedOutput[THROTTLE_OUT_CHANNEL] <= 100.0f ) && (mixedOutput[THROTTLE_OUT_CHANNEL] >= 0.0f ) );
+
+}


### PR DESCRIPTION
2 commits in this PR. The earlier one just renames the "sendToActuators" module to "SendInstructionsToSafety". I could have have sworn I did this in a previous PR but apparently not. *Sigh*.

Second commit is the complete implementation of the OutputMixing module, along with the relevant unit tests.