### PR TITLE
Fixed "undefined vtable" bug

### DIFF
--- a/Autopilot/AttitudeManager/attitudeStateClasses.hpp
+++ b/Autopilot/AttitudeManager/attitudeStateClasses.hpp
@@ -19,6 +19,11 @@
 #define IMU_CLASS SimulatedIMU
 #define AIRSPEED_CLASS SimulatedAirspeed
 
+#elif defined(UNIT_TESTING)
+
+#define IMU_CLASS MockIMU
+#define AIRSPEED_CLASS MockAirspeed
+
 #else
 
 #define IMU_CLASS ICM20602  // TODO to be replaced with the real classes once the sensor drivers are built

--- a/Autopilot/CMakeLists.txt
+++ b/Autopilot/CMakeLists.txt
@@ -96,6 +96,8 @@ elseif(${KIND_OF_BUILD} STREQUAL "UNIT_TESTS")
     -DARM_MATH_CM7
   )
 
+  add_definitions(-DUNIT_TESTING)
+
   # Required to get some of the CMSIS libraries to compile
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive -fms-extensions -Wall -Wextra -g")
 

--- a/Autopilot/Inc/IMU.hpp
+++ b/Autopilot/Inc/IMU.hpp
@@ -64,4 +64,8 @@ class ICM20602: public IMU{
 
 };
 
+#ifdef UNIT_TESTING
+#include "IMU_Mock.hpp"
+#endif
+
 #endif

--- a/Autopilot/Inc/airspeed.hpp
+++ b/Autopilot/Inc/airspeed.hpp
@@ -84,4 +84,9 @@ class dummyairspeed: public airspeed{
 
 };
 
+
+#ifdef UNIT_TESTING
+#include "airspeed_Mock.hpp"
+#endif
+
 #endif


### PR DESCRIPTION
Because the implementations of certain abstract classes where not
present during unit testing (hardware drivers), certain linkers on
certain platforms threw the undefined vtable error, even though the
methods were never called. The solution to this involved making sure the
corresponding mock classes were always around. This way, there is always
an implementation to be found. In practice, this involved adding a
"UNIT_TESTING" flag to the build and using preprocessor macros to
include the mock classes into the correct header files when needed.