### PR TITLE
Safety changes

### DIFF
--- a/Autopilot/AttitudeManager/SendInstructionsToSafety.cpp
+++ b/Autopilot/AttitudeManager/SendInstructionsToSafety.cpp
@@ -18,6 +18,8 @@ SendToSafety_error_t SendToSafety_Execute(int channel, int percent)
 {
     SendToSafety_error_t error;
     error.errorCode = 0;
+    //TODO: Add in something that can update the error code if required
+    //THIS IS TOP LEVEL PRIORITY ONCE INTERCHIP IS WRITTEN!!
     pwmPercentages[channel] = percent;
 
     Interchip_SetPWM(pwmPercentages);

--- a/Autopilot/AttitudeManager/SendInstructionsToSafety.cpp
+++ b/Autopilot/AttitudeManager/SendInstructionsToSafety.cpp
@@ -2,8 +2,8 @@
 #include "Interchip_A.h"
 #define PWM_CHANNELS 12
 
-int16_t pwmPercentages[PWM_CHANNELS] = {0};
-int16_t initialPWMPercentages[PWM_CHANNELS] = {0}; //TODO: put in initial PWM states in here. 
+static int16_t pwmPercentages[PWM_CHANNELS] = {0};
+static int16_t initialPWMPercentages[PWM_CHANNELS] = {0}; //TODO: put in initial PWM states in here. 
 
 
 void SendToSafety_Init(void)

--- a/Autopilot/AttitudeManager/SendInstructionsToSafety.cpp
+++ b/Autopilot/AttitudeManager/SendInstructionsToSafety.cpp
@@ -1,5 +1,5 @@
 #include "SendInstructionsToSafety.hpp"
-#include "interchip_A.h"
+#include "Interchip_A.h"
 #define PWM_CHANNELS 12
 
 int16_t pwmPercentages[PWM_CHANNELS] = {0};

--- a/Autopilot/AttitudeManager/SendInstructionsToSafety.cpp
+++ b/Autopilot/AttitudeManager/SendInstructionsToSafety.cpp
@@ -1,0 +1,24 @@
+#include "SendInstructionsToSafety.hpp"
+#include "interchip_A.h"
+#define PWM_CHANNELS 12
+
+int16_t pwmPercentages[PWM_CHANNELS] = {0};
+int16_t initialPWMPercentages[PWM_CHANNELS] = {0}; //TODO: put in initial PWM states in here. 
+
+
+static void SendToSafety_Init(void)
+{
+    for(int i = 0; i < PWM_CHANNELS; i++)
+    {
+        pwmPercentages[i] = initialPWMPercentages[i];
+    }
+}
+
+static SendToSafety_error_t SendToSafety_Execute(int channel, int percent)
+{
+    SendToSafety_error_t error;
+    pwmPercentages[channel] = percent;
+
+    Interchip_SetPWM(pwmPercentages);
+    return error;
+}

--- a/Autopilot/AttitudeManager/SendInstructionsToSafety.cpp
+++ b/Autopilot/AttitudeManager/SendInstructionsToSafety.cpp
@@ -6,7 +6,7 @@ int16_t pwmPercentages[PWM_CHANNELS] = {0};
 int16_t initialPWMPercentages[PWM_CHANNELS] = {0}; //TODO: put in initial PWM states in here. 
 
 
-static void SendToSafety_Init(void)
+void SendToSafety_Init(void)
 {
     for(int i = 0; i < PWM_CHANNELS; i++)
     {
@@ -14,9 +14,10 @@ static void SendToSafety_Init(void)
     }
 }
 
-static SendToSafety_error_t SendToSafety_Execute(int channel, int percent)
+SendToSafety_error_t SendToSafety_Execute(int channel, int percent)
 {
     SendToSafety_error_t error;
+    error.errorCode = 0;
     pwmPercentages[channel] = percent;
 
     Interchip_SetPWM(pwmPercentages);

--- a/Autopilot/AttitudeManager/SendInstructionsToSafety.hpp
+++ b/Autopilot/AttitudeManager/SendInstructionsToSafety.hpp
@@ -32,7 +32,7 @@ void SendToSafety_Init(void);
 * Communicates the desired actuator commands encoded in the channelOut array over I2C to
 * the safety chip. Internally, this function performs a conversion from percentages to pwm values.
 * This function is non blocking and returns right away.
-* @param[in]		channelOut 		the output channel for PWM
+* @param[in]		channel 		the output channel for PWM
 * @param[in]		percent 		the percentage between 0-100 that the PWM channel should be set to
 * @return							the error struct, containing all info about any errors that may have occured.
 */

--- a/Autopilot/AttitudeManager/SendInstructionsToSafety.hpp
+++ b/Autopilot/AttitudeManager/SendInstructionsToSafety.hpp
@@ -11,6 +11,7 @@
  * Definitions
  **********************************************************************************************************************/
 
+
 typedef struct
 {
 	int errorCode; // 0 if all is successfull. Other values correspond to various errors which are tbd.
@@ -25,15 +26,16 @@ typedef struct
 * Initialises internal parameters and instructs the safety to set all actuator channels to their default safe settings.
 * Should be called exactly once before anything is attempted to be done with the module.
 */
-void SendToSafety_Init(void);
+static void SendToSafety_Init(void);
 
 /**
 * Communicates the desired actuator commands encoded in the channelOut array over I2C to
 * the safety chip. Internally, this function performs a conversion from percentages to pwm values.
 * This function is non blocking and returns right away.
-* @param[in]		channelOut 		the array (size of 4 floats) of percentages each channel should be set to.
+* @param[in]		channelOut 		the output channel for PWM
+* @param[in]		percent 		the percentage between 0-100 that the PWM channel should be set to
 * @return							the error struct, containing all info about any errors that may have occured.
 */
-SendToSafety_error_t SendToSafety_Execute(float *channelOut);
+static SendToSafety_error_t SendToSafety_Execute(int channel, int percent);
 
 #endif

--- a/Autopilot/AttitudeManager/SendInstructionsToSafety.hpp
+++ b/Autopilot/AttitudeManager/SendInstructionsToSafety.hpp
@@ -26,7 +26,7 @@ typedef struct
 * Initialises internal parameters and instructs the safety to set all actuator channels to their default safe settings.
 * Should be called exactly once before anything is attempted to be done with the module.
 */
-static void SendToSafety_Init(void);
+void SendToSafety_Init(void);
 
 /**
 * Communicates the desired actuator commands encoded in the channelOut array over I2C to
@@ -36,6 +36,6 @@ static void SendToSafety_Init(void);
 * @param[in]		percent 		the percentage between 0-100 that the PWM channel should be set to
 * @return							the error struct, containing all info about any errors that may have occured.
 */
-static SendToSafety_error_t SendToSafety_Execute(int channel, int percent);
+SendToSafety_error_t SendToSafety_Execute(int channel, int percent);
 
 #endif

--- a/Autopilot/AttitudeManager/attitudeStateClasses.cpp
+++ b/Autopilot/AttitudeManager/attitudeStateClasses.cpp
@@ -107,6 +107,7 @@ void sendToSafetyMode::execute(attitudeManager* attitudeMgr)
         if(ErrorStruct.errorCode == 1)
         {
             attitudeMgr->setState(FatalFailureMode::getInstance());
+            break;
         }
     }
 

--- a/Autopilot/AttitudeManager/attitudeStateClasses.cpp
+++ b/Autopilot/AttitudeManager/attitudeStateClasses.cpp
@@ -104,17 +104,15 @@ void sendToSafetyMode::execute(attitudeManager* attitudeMgr)
     for(int channel = 0; channel < 4; channel++)
     {
         ErrorStruct = SendToSafety_Execute(channel, channelOut[channel]);
+        if(ErrorStruct.errorCode == 0)
+        {
+            attitudeMgr->setState(FatalFailureMode::getInstance());
+        }
     }
-
-    SendToSafety_error_t ErrorStruct = SendToSafety_Execute(channelOut);
 
     if (ErrorStruct.errorCode == 0)
     {
         attitudeMgr->setState(fetchInstructionsMode::getInstance());
-    }
-    else
-    {
-        attitudeMgr->setState(FatalFailureMode::getInstance());
     }
 
 }

--- a/Autopilot/AttitudeManager/attitudeStateClasses.cpp
+++ b/Autopilot/AttitudeManager/attitudeStateClasses.cpp
@@ -99,7 +99,12 @@ attitudeState& OutputMixingMode::getInstance()
 
 void sendToSafetyMode::execute(attitudeManager* attitudeMgr)
 {
+    SendToSafety_error_t ErrorStruct;
     float *channelOut = OutputMixingMode::GetChannelOut();
+    for(int channel = 0; channel < 4; channel++)
+    {
+        ErrorStruct = SendToSafety_Execute(channel, channelOut[channel]);
+    }
 
     SendToSafety_error_t ErrorStruct = SendToSafety_Execute(channelOut);
 

--- a/Autopilot/AttitudeManager/attitudeStateClasses.cpp
+++ b/Autopilot/AttitudeManager/attitudeStateClasses.cpp
@@ -104,7 +104,7 @@ void sendToSafetyMode::execute(attitudeManager* attitudeMgr)
     for(int channel = 0; channel < 4; channel++)
     {
         ErrorStruct = SendToSafety_Execute(channel, channelOut[channel]);
-        if(ErrorStruct.errorCode == 0)
+        if(ErrorStruct.errorCode == 1)
         {
             attitudeMgr->setState(FatalFailureMode::getInstance());
         }

--- a/Autopilot/Src/Interchip_A.c
+++ b/Autopilot/Src/Interchip_A.c
@@ -31,8 +31,13 @@ void Interchip_Run(void const *argument) {
 
 // Public Functions to get and set data
 
-int16_t *Interchip_GetPWM(void) { return dataRX->PWM; }
-void Interchip_SetPWM(int16_t *data) {
+int16_t *Interchip_GetPWM(void) 
+{ 
+  return dataRX->PWM; 
+}
+
+
+void Interchip_SetPWM(int16_t data[]) {
   osMutexWait(Interchip_MutexHandle, 0);
   for (uint8_t i = 0; i < 12; i++) {
     dataTX->PWM[i] = data[i];

--- a/Autopilot/Test/Src/AttitudeManager/Test_Fsm.cpp
+++ b/Autopilot/Test/Src/AttitudeManager/Test_Fsm.cpp
@@ -26,7 +26,7 @@ using ::testing::Test;
 FAKE_VALUE_FUNC(PMError_t, PM_GetCommands, PMCommands * );
 FAKE_VALUE_FUNC(SFError_t, SF_GetResult, SFOutput_t *, IMU *, airspeed *);
 FAKE_VALUE_FUNC(OutputMixing_error_t, OutputMixing_Execute, PID_Output_t * , float * );
-FAKE_VALUE_FUNC(SendToSafety_error_t, SendToSafety_Execute, float * );
+FAKE_VALUE_FUNC(SendToSafety_error_t, SendToSafety_Execute, int, int);
 
 /***********************************************************************************************************************
  * Definitions


### PR DESCRIPTION
Changed the way PWM is given to safety.

- Now, anything can call send to safety (i.e. camera gimbal, output mixing, etc) as much as it needs without having to account for anything else