### PR TITLE
Changed all ASSERT_'s to EXPECT_'s

### DIFF
--- a/Autopilot/Test/Src/AttitudeManager/Test_Fsm.cpp
+++ b/Autopilot/Test/Src/AttitudeManager/Test_Fsm.cpp
@@ -109,7 +109,7 @@ TEST(AttitudeManagerFSM, InitialStateIsFetchInstructions) {
 	/********************STEPTHROUGH********************/
 	/**********************ASSERTS**********************/
 
-	ASSERT_EQ(*(attMng.getCurrentState()), fetchInstructionsMode::getInstance());
+	EXPECT_EQ(*(attMng.getCurrentState()), fetchInstructionsMode::getInstance());
 
 }
 
@@ -133,7 +133,7 @@ TEST(AttitudeManagerFSM, IfFetchInstructionsSucceedsTransitionToSensorFusion) {
 
 	/**********************ASSERTS**********************/
 
-	ASSERT_EQ(*(attMng.getCurrentState()), sensorFusionMode::getInstance());
+	EXPECT_EQ(*(attMng.getCurrentState()), sensorFusionMode::getInstance());
 
 }
 
@@ -157,7 +157,7 @@ TEST(AttitudeManagerFSM, IfFetchInstructionsFailsTransitionToFatalFailure) {
 
 	/**********************ASSERTS**********************/
 
-	ASSERT_EQ(*(attMng.getCurrentState()), FatalFailureMode::getInstance());
+	EXPECT_EQ(*(attMng.getCurrentState()), FatalFailureMode::getInstance());
 
 }
 
@@ -180,7 +180,7 @@ TEST(AttitudeManagerFSM, IfSensorFusionSucceedsTransitionToPID) {
 
 	/**********************ASSERTS**********************/
 
-	ASSERT_EQ(*(attMng.getCurrentState()), PIDloopMode::getInstance());
+	EXPECT_EQ(*(attMng.getCurrentState()), PIDloopMode::getInstance());
 }
 
 TEST(AttitudeManagerFSM, IfSensorFusionFailsTransitionToFailed) {
@@ -202,7 +202,7 @@ TEST(AttitudeManagerFSM, IfSensorFusionFailsTransitionToFailed) {
 
 	/**********************ASSERTS**********************/
 
-	ASSERT_EQ(*(attMng.getCurrentState()), FatalFailureMode::getInstance());
+	EXPECT_EQ(*(attMng.getCurrentState()), FatalFailureMode::getInstance());
 }
 
 
@@ -220,7 +220,7 @@ TEST(AttitudeManagerFSM, TransitionFromPIDToOutputMixing) {
 
 	/**********************ASSERTS**********************/
 
-	ASSERT_EQ(*(attMng.getCurrentState()), OutputMixingMode::getInstance());
+	EXPECT_EQ(*(attMng.getCurrentState()), OutputMixingMode::getInstance());
 }
 
 TEST(AttitudeManagerFSM, IfOutputMixingSucceedsTransitionToSendToSafety) {
@@ -242,7 +242,7 @@ TEST(AttitudeManagerFSM, IfOutputMixingSucceedsTransitionToSendToSafety) {
 
 	/**********************ASSERTS**********************/
 
-	ASSERT_EQ(*(attMng.getCurrentState()), sendToSafetyMode::getInstance());
+	EXPECT_EQ(*(attMng.getCurrentState()), sendToSafetyMode::getInstance());
 }
 
 TEST(AttitudeManagerFSM, IfOutputMixingFailsTransitionToFailed) {
@@ -264,7 +264,7 @@ TEST(AttitudeManagerFSM, IfOutputMixingFailsTransitionToFailed) {
 
 	/**********************ASSERTS**********************/
 
-	ASSERT_EQ(*(attMng.getCurrentState()), FatalFailureMode::getInstance());
+	EXPECT_EQ(*(attMng.getCurrentState()), FatalFailureMode::getInstance());
 }
 
 TEST(AttitudeManagerFSM, IfSendToSafetySucceedsTransitionToFetchInstructions) {
@@ -286,7 +286,7 @@ TEST(AttitudeManagerFSM, IfSendToSafetySucceedsTransitionToFetchInstructions) {
 
 	/**********************ASSERTS**********************/
 
-	ASSERT_EQ(*(attMng.getCurrentState()), fetchInstructionsMode::getInstance());
+	EXPECT_EQ(*(attMng.getCurrentState()), fetchInstructionsMode::getInstance());
 }
 
 TEST(AttitudeManagerFSM, IfSendToSafetyFailsTransitionToFailed) {
@@ -308,7 +308,7 @@ TEST(AttitudeManagerFSM, IfSendToSafetyFailsTransitionToFailed) {
 
 	/**********************ASSERTS**********************/
 
-	ASSERT_EQ(*(attMng.getCurrentState()), FatalFailureMode::getInstance());
+	EXPECT_EQ(*(attMng.getCurrentState()), FatalFailureMode::getInstance());
 }
 
 /***********************************************************************************************************************
@@ -338,6 +338,6 @@ TEST(AttitudeManagerDataHandoff, CorrectDataIsFedFromOutputMixingToSendToSafety)
 
 	/**********************ASSERTS**********************/
 
-	ASSERT_EQ(0, memcmp(OutputMixing_Execute_fake.arg1_val, channelOut_custom, 4*sizeof(float)));
+	EXPECT_EQ(0, memcmp(OutputMixing_Execute_fake.arg1_val, channelOut_custom, 4*sizeof(float)));
 }
 

--- a/Autopilot/Test/Src/AttitudeManager/Test_OutputMixing.cpp
+++ b/Autopilot/Test/Src/AttitudeManager/Test_OutputMixing.cpp
@@ -32,7 +32,7 @@ TEST(AttitudeManager_OutputMixing, UnderNegative100RollReturnsError1) {
 
 	/**********************ASSERTS**********************/
 
-	ASSERT_EQ(error.errorCode, 1);
+	EXPECT_EQ(error.errorCode, 1);
 }
 
 TEST(AttitudeManager_OutputMixing, UnderNegative100PitchReturnsError1) {
@@ -57,7 +57,7 @@ TEST(AttitudeManager_OutputMixing, UnderNegative100PitchReturnsError1) {
 
 	/**********************ASSERTS**********************/
 
-	ASSERT_EQ(error.errorCode, 1);
+	EXPECT_EQ(error.errorCode, 1);
 }
 
 TEST(AttitudeManager_OutputMixing, UnderNegative100YawReturnsError1) {
@@ -82,7 +82,7 @@ TEST(AttitudeManager_OutputMixing, UnderNegative100YawReturnsError1) {
 
 	/**********************ASSERTS**********************/
 
-	ASSERT_EQ(error.errorCode, 1);
+	EXPECT_EQ(error.errorCode, 1);
 }
 
 TEST(AttitudeManager_OutputMixing, NegativeThrottleReturnsError1) {
@@ -107,7 +107,7 @@ TEST(AttitudeManager_OutputMixing, NegativeThrottleReturnsError1) {
 
 	/**********************ASSERTS**********************/
 
-	ASSERT_EQ(error.errorCode, 1);
+	EXPECT_EQ(error.errorCode, 1);
 }
 
 TEST(AttitudeManager_OutputMixing, Over100RollReturnsError2) {
@@ -132,7 +132,7 @@ TEST(AttitudeManager_OutputMixing, Over100RollReturnsError2) {
 
 	/**********************ASSERTS**********************/
 
-	ASSERT_EQ(error.errorCode, 2);
+	EXPECT_EQ(error.errorCode, 2);
 }
 
 TEST(AttitudeManager_OutputMixing, Over100PitchReturnsError2) {
@@ -157,7 +157,7 @@ TEST(AttitudeManager_OutputMixing, Over100PitchReturnsError2) {
 
 	/**********************ASSERTS**********************/
 
-	ASSERT_EQ(error.errorCode, 2);
+	EXPECT_EQ(error.errorCode, 2);
 }
 
 TEST(AttitudeManager_OutputMixing, Over100YawReturnsError2) {
@@ -182,7 +182,7 @@ TEST(AttitudeManager_OutputMixing, Over100YawReturnsError2) {
 
 	/**********************ASSERTS**********************/
 
-	ASSERT_EQ(error.errorCode, 2);
+	EXPECT_EQ(error.errorCode, 2);
 }
 
 TEST(AttitudeManager_OutputMixing, Over100ThrottleReturnsError2) {
@@ -207,7 +207,7 @@ TEST(AttitudeManager_OutputMixing, Over100ThrottleReturnsError2) {
 
 	/**********************ASSERTS**********************/
 
-	ASSERT_EQ(error.errorCode, 2);
+	EXPECT_EQ(error.errorCode, 2);
 }
 
 TEST(AttitudeManager_OutputMixing, AllInputValidReturnsError0) {
@@ -232,7 +232,7 @@ TEST(AttitudeManager_OutputMixing, AllInputValidReturnsError0) {
 
 	/**********************ASSERTS**********************/
 
-	ASSERT_EQ(error.errorCode, 0);
+	EXPECT_EQ(error.errorCode, 0);
 }
 
 TEST(AttitudeManager_OutputMixing, CannotReturnOutOfRangeValuesWhenGivenValidInput) {
@@ -257,11 +257,11 @@ TEST(AttitudeManager_OutputMixing, CannotReturnOutOfRangeValuesWhenGivenValidInp
 
 	/**********************ASSERTS**********************/
 
-	ASSERT_EQ(error.errorCode, 0);
+	EXPECT_EQ(error.errorCode, 0);
 
-	ASSERT_TRUE( (mixedOutput[L_TAIL_OUT_CHANNEL] <= 100.0f ) && (mixedOutput[L_TAIL_OUT_CHANNEL] >= -100.0f ) );
-	ASSERT_TRUE( (mixedOutput[R_TAIL_OUT_CHANNEL] <= 100.0f ) && (mixedOutput[R_TAIL_OUT_CHANNEL] >= -100.0f ) );
-	ASSERT_TRUE( (mixedOutput[AILERON_OUT_CHANNEL] <= 100.0f ) && (mixedOutput[AILERON_OUT_CHANNEL] >= -100.0f ) );
-	ASSERT_TRUE( (mixedOutput[THROTTLE_OUT_CHANNEL] <= 100.0f ) && (mixedOutput[THROTTLE_OUT_CHANNEL] >= 0.0f ) );
+	EXPECT_TRUE( (mixedOutput[L_TAIL_OUT_CHANNEL] <= 100.0f ) && (mixedOutput[L_TAIL_OUT_CHANNEL] >= -100.0f ) );
+	EXPECT_TRUE( (mixedOutput[R_TAIL_OUT_CHANNEL] <= 100.0f ) && (mixedOutput[R_TAIL_OUT_CHANNEL] >= -100.0f ) );
+	EXPECT_TRUE( (mixedOutput[AILERON_OUT_CHANNEL] <= 100.0f ) && (mixedOutput[AILERON_OUT_CHANNEL] >= -100.0f ) );
+	EXPECT_TRUE( (mixedOutput[THROTTLE_OUT_CHANNEL] <= 100.0f ) && (mixedOutput[THROTTLE_OUT_CHANNEL] >= 0.0f ) );
 
 }

--- a/Autopilot/Test/Src/AttitudeManager/Test_SensorFusion.cpp
+++ b/Autopilot/Test/Src/AttitudeManager/Test_SensorFusion.cpp
@@ -61,7 +61,7 @@ TEST(SensorFusion, FailedBusyIMUDataReturnsNegative1) {
 
 	/**********************ASSERTS**********************/
 
-	ASSERT_EQ(error.errorCode, -1);
+	EXPECT_EQ(error.errorCode, -1);
 }
 
 TEST(SensorFusion, FailedBusyAirspeedDataReturnsNegative1 ) {
@@ -93,7 +93,7 @@ TEST(SensorFusion, FailedBusyAirspeedDataReturnsNegative1 ) {
 
 	/**********************ASSERTS**********************/
 
-	ASSERT_EQ(error.errorCode, -1);
+	EXPECT_EQ(error.errorCode, -1);
 }
 
 TEST(SensorFusion, OldDataReturns1) {
@@ -139,6 +139,6 @@ TEST(SensorFusion, OldDataReturns1) {
 
 	/**********************ASSERTS**********************/
 
-	ASSERT_EQ(error.errorCode, 1);
+	EXPECT_EQ(error.errorCode, 1);
 }
 

--- a/Autopilot/Test/Src/Test_Altimeter_Skeleton.cpp
+++ b/Autopilot/Test/Src/Test_Altimeter_Skeleton.cpp
@@ -84,7 +84,7 @@ TEST_F(ExampleClass, ExampleTest) {
 	/********************STEPTHROUGH********************/
 	/**********************ASSERTS**********************/
 
-	ASSERT_EQ(true, true);
+	EXPECT_EQ(true, true);
 }
 
 TEST_F(ExampleClass2, ExampleTest) {
@@ -94,6 +94,6 @@ TEST_F(ExampleClass2, ExampleTest) {
 	/********************STEPTHROUGH********************/
 	/**********************ASSERTS**********************/
 
-	ASSERT_LT(5.1, 7.0);
+	EXPECT_LT(5.1, 7.0);
 }
 

--- a/Autopilot/Test/Src/Test_PID.cpp
+++ b/Autopilot/Test/Src/Test_PID.cpp
@@ -25,7 +25,7 @@ TEST(PID, OutputCannotBeLargerThanMaxOutput) {
 
 	/**********************ASSERTS**********************/
 
-	ASSERT_EQ(output, maxOutput);
+	EXPECT_EQ(output, maxOutput);
 }
 
 TEST(PID, OutputCannotBeSmallerThanMinOutput) {
@@ -43,5 +43,5 @@ TEST(PID, OutputCannotBeSmallerThanMinOutput) {
 
 	/**********************ASSERTS**********************/
 
-	ASSERT_EQ(output, minOutput);
+	EXPECT_EQ(output, minOutput);
 }


### PR DESCRIPTION
When I was developing the waypoint manager, the ASSERT_ commands made testing a lot harder since it would stop tests when the first condition failed. This wasn't ideal since in some cases multiple tests failed (and knowing this would have helped me find the source of the problem faster). 

Note: I changed all of the files in `./Autopilot/Test/Src/`. Let me know if I missed anything. VS Code said I got rid of em all.

As a result, I believe it is best that we switch all asserts to expects. 

I ran `./Tools/build.bash -c -t` multiple times and all tests passed each time. 

Also cool resource to learn how to cherry pick commits for PRs: https://poanchen.github.io/blog/2017/11/12/How-to-create-a-GitHub-pull-request-with-a-specific-commits