### PR TITLE
FIxed the simulation build

### DIFF
--- a/Autopilot/CMakeLists.txt
+++ b/Autopilot/CMakeLists.txt
@@ -271,6 +271,7 @@ elseif(${KIND_OF_BUILD} STREQUAL "SIMULATION")
     ${CMAKE_CURRENT_SOURCE_DIR}/AttitudeManager/Src/OutputMixing.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/AttitudeManager/Src/SensorFusion.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/AttitudeManager/Src/MadgwickAHRS.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/AttitudeManager/Src/fetchSensorMeasurementsMode.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Src/PID.cpp
   )
 


### PR DESCRIPTION
There was a new file added to the target build that wasn't added to the simulation build causing linker error. That file has now been added.