### PR TITLE
Fix PPM Hardfaults

### DIFF
--- a/Safety/Src/PPM.cpp
+++ b/Safety/Src/PPM.cpp
@@ -12,7 +12,7 @@ const float SEC_TO_MICROSEC = 1000000.0f;
 const float BASE_FREQUENCY = 48000000.0f;
 
 const float PULSE_WIDTH = 310.0f; // in us
-const float MIN_WIDTH_OF_RESET_PULSE = 5000.0f; // not really a pulse, this is slightly smaller than the difference in time between sequential PPM packets
+const float MIN_WIDTH_OF_RESET_PULSE = 3000.0f; // not really a pulse, this is slightly smaller than the difference in time between sequential PPM packets
 const float MIN_PULSE_WIDTH = 700.0f;
 const float MAX_PULSE_WIDTH = 1670.0f;
 
@@ -143,7 +143,7 @@ void HAL_TIM_IC_CaptureCallback(TIM_HandleTypeDef *htim)
 		{
 			index = 0;
 		}
-		else
+		else if (index < MAX_PPM_CHANNELS)
 		{
 			ppm_values[index] = pulseLength;
 			index++;


### PR DESCRIPTION
# Description

This PR (hopefully) fixes the hardfault that was plaguing safety whenever the receiver was plugged into ppm. Before, after a few seconds, safety would hardfault, but only after the receiver was connected and the transmitter was powered on.

`MIN_WIDTH_OF_PULSE_RESET` was changed to 3000 based on the output from the scope, where a reset pulse is 4000ms (This is probably something to do with the transmitter configuration being changed, but 5000ms was perhaps a little excessive)

## Testing

There does not appear to be any more hard faults. So hopefully resolved?
Tested on ZP breakout with new transmitter.

## ~~Documentation~~


# Merge Checklist:

- [x] The changes have been well commented, particularly in hard-to-understand areas.
- [x] The code has been tested on hardware, either by me or somone else.
~~- [ ] Comprehensive unit tests have been made for this change~~
~~- [ ] Corresponding changes to documentation have been created and links to this documentation are provided within the pull request.~~
- [x] The changes generate no new warnings and compile and run; A screenshot of a successful compile message is attached to the bottom of this PR.

![2022-04-03_16:25:42_screenshot](https://user-images.githubusercontent.com/31750217/161447127-96d3d380-a06d-4c7f-9fa6-635b0aa7eecc.png)

