### PR TITLE
change pwm set from uint8 to float

### DIFF
--- a/Safety/Inc/PWM.hpp
+++ b/Safety/Inc/PWM.hpp
@@ -67,7 +67,7 @@ typedef enum dshotType
 class PWMChannel {
 public:
 	PWMChannel();
-	void set(uint8_t channel, uint8_t percent);
+	void set(uint8_t channel, float percent);
 private:
 	//values in us
 	uint32_t pwmPeriod = 20000;
@@ -80,7 +80,7 @@ private:
   * @param telemetry Bool indicating whether to set the telemetry bit or not
   * @retval 16 bit dshot data frame
   */    
-    uint16_t dshotPrepareFrame(uint8_t throttlePercentage, bool telemetry);
+    uint16_t dshotPrepareFrame(float throttlePercentage, bool telemetry);
 
 /**
   * @brief Prepares the DMA buffer using the data frame
@@ -88,7 +88,7 @@ private:
   * @param frame DSHOT data frame
   * @retval None
   */    
-    void dshotPrepareDMABuffer(uint32_t * dmaBuffer, uint8_t throttlePercentage);
+    void dshotPrepareDMABuffer(uint32_t * dmaBuffer, float throttlePercentage);
 
 /**
   * @brief Starts PWM generation of channels 1-4 on TIM1


### PR DESCRIPTION
# Description

For dshot enabled channels, pwm.set() now makes use of float for greater motor resolution than  it did with uint8 percent inputs.
https://app.asana.com/0/187002107997407/1202137816267636

## Testing

Tested by running motors from 0-25 percent, mapped from 0-100 from ppm input.

## Documentation

No documentation changes made

# Merge Checklist:

- [x] The changes have been well commented, particularly in hard-to-understand areas.
- [x] The code has been tested on hardware, either by me or somone else.
~- [ ] Comprehensive unit tests have been made for this change~
~- [ ] Corresponding changes to documentation have been created and links to this documentation are provided within the pull request.~
- [x] The changes generate no new warnings and compile and run; A screenshot of a successful compile message is attached to the bottom of this PR.
