### PR TITLE
Add altitude-hold PID method

### DIFF
--- a/Safety/Controls/Src/Controls.cpp
+++ b/Safety/Controls/Src/Controls.cpp
@@ -52,10 +52,8 @@ const int max_i_windup = 5;  // ? not sure if we need specifics for each angle
 // const float yaw_ki = 0;
 // const float yaw_kd = 0;
 
-
-
 // FIXME: this is to be defined in the code later depending on switch positions
-int PID_method = 0; // 0 = acro, 1 = hold altitude, 2 = hold location
+int PID_method = 0;  // 0 = acro, 1 = hold altitude, 2 = hold location
 
 /***********************************************************************************************************************
  * Code
@@ -65,12 +63,12 @@ PID_Output_t *runControlsAndGetPWM(Instructions_t *instructions, SFOutput_t *SF_
   // to use or not to use pointers?
   curr_sf = *SF_pos;
 
-  int prev_PID_method = 0; // default is acro
+  int prev_PID_method = 0;  // default is acro
   // =================================
   // PID Code Begins here.
   // =================================
-  if (PID_method < 0 || PID_method >2) {
-    PID_method = 0; // set to default acro mode
+  if (PID_method < 0 || PID_method > 2) {
+    PID_method = 0;  // set to default acro mode
   }
   if (PID_method == 0) {
     // acro mode
@@ -111,6 +109,7 @@ PID_Output_t *runControlsAndGetPWM(Instructions_t *instructions, SFOutput_t *SF_
     PID_Out.backRightMotorPercent = throttle + roll - pitch + yaw;
     PID_Out.frontRightMotorPercent = throttle + roll + pitch - yaw;
   } else if (PID_method == 1) {
+    // PID method 1 = Hold current altitude
     if (prev_PID_method != PID_method) {
       // we have just toggled the PID method, so save height location
       prev_sf = curr_sf;  // not sure about the pointer operation...
@@ -155,7 +154,7 @@ PID_Output_t *runControlsAndGetPWM(Instructions_t *instructions, SFOutput_t *SF_
     PID_Out.backRightMotorPercent = throttle + roll - pitch + yaw;
     PID_Out.frontRightMotorPercent = throttle + roll + pitch - yaw;
   } else if (PID_method == 2) {
-    // HOLD LOCATION
+    // Pid method 2 = HOLD LOCATION
     // EXTREMELY UNTESTED, probably not usable
     // lat = roll = left/right ; lon = pitc = front/back ; alt = throttle = up/down ; yaw = yaw = rotation
     if (prev_PID_method != PID_method) {
@@ -192,7 +191,7 @@ PID_Output_t *runControlsAndGetPWM(Instructions_t *instructions, SFOutput_t *SF_
 
     // yaw is now going to target a specific yawrate.
     // FIXME: double check that the yawRate matches direction from stick
-    float yaw = pid_yaw.execute(0, curr_sf.yawRate); // no yaw rate
+    float yaw = pid_yaw.execute(0, curr_sf.yawRate);                       // no yaw rate
     float alt = pid_altitude.execute(prev_sf.altitude, curr_sf.altitude);  // desired is the one assigned on toggle
 
     // mix the PID's.
@@ -200,6 +199,8 @@ PID_Output_t *runControlsAndGetPWM(Instructions_t *instructions, SFOutput_t *SF_
     PID_Out.frontLeftMotorPercent = alt - lat + lon + yaw;
     PID_Out.backRightMotorPercent = alt + lat - lon + yaw;
     PID_Out.frontRightMotorPercent = alt + lat + lon - yaw;
+  } else if (PID_method == 3) {
+    // some other mode not yet implemented
   }
   return &PID_Out;
 }

--- a/Safety/Controls/Src/Controls.cpp
+++ b/Safety/Controls/Src/Controls.cpp
@@ -31,6 +31,7 @@
  **********************************************************************************************************************/
 
 static SFOutput_t curr_sf;  // current
+static SFOutput_t prev_sf;  // previous
 static PID_Output_t PID_Out;
 
 // =======================================================
@@ -51,22 +52,10 @@ const int max_i_windup = 5;  // ? not sure if we need specifics for each angle
 // const float yaw_ki = 0;
 // const float yaw_kd = 0;
 
-const float roll_kp = 0.05;
-const float roll_ki = 0;
-const float roll_kd = 0.05;
-
-const float pitch_kp = 0.05;
-const float pitch_ki = 0;
-const float pitch_kd = 0.05;
-
-const float yaw_kp = 0.25;
-const float yaw_ki = 0;
-const float yaw_kd = 0.05;
 
 
-
-
-const int PID_method = 0;
+// FIXME: this is to be defined in the code later depending on switch positions
+const int PID_method = 0; // 0 = acro, 1 = hold altitude, 2 = hold location
 
 /***********************************************************************************************************************
  * Code
@@ -76,31 +65,92 @@ PID_Output_t *runControlsAndGetPWM(Instructions_t *instructions, SFOutput_t *SF_
   // to use or not to use pointers?
   curr_sf = *SF_pos;
 
+  int prev_PID_Method = 0; // default is acro
   // =================================
   // PID Code Begins here.
   // =================================
+  if (PID_method == 0) {
+    // acro mode
+    // PIDController controller(float _kp, float _ki, float _kd, float _i_max,
+    // float _min_output, float _max_output);
 
-  // PIDController controller(float _kp, float _ki, float _kd, float _i_max,
-  // float _min_output, float _max_output);
-  PIDController pid_roll{roll_kp, roll_ki, roll_kd, max_i_windup, -pid_abs_max, pid_abs_max};
+    // ? is redifining these everytime costly? should we leave them at the top? Compiler should take care of this right?
+    const float roll_kp = 0.05;
+    const float roll_ki = 0;
+    const float roll_kd = 0.05;
 
-  PIDController pid_pitch{pitch_kp, pitch_ki, pitch_kd, max_i_windup, -pid_abs_max, pid_abs_max};
+    const float pitch_kp = 0.05;
+    const float pitch_ki = 0;
+    const float pitch_kd = 0.05;
 
-  PIDController pid_yaw{yaw_kp, yaw_ki, yaw_kd, max_i_windup, -pid_abs_max, pid_abs_max};
+    const float yaw_kp = 0.25;
+    const float yaw_ki = 0;
+    const float yaw_kd = 0.05;
 
-  // get PID result
-  float roll = pid_roll.execute(instructions->input1, curr_sf.roll, curr_sf.rollRate);
-  float pitch = pid_pitch.execute(instructions->input2, curr_sf.pitch, curr_sf.pitchRate);
+    PIDController pid_roll{roll_kp, roll_ki, roll_kd, max_i_windup, -pid_abs_max, pid_abs_max};
 
-  // yaw is now going to target a specific yawrate.
-  // FIXME: double check that the yawRate matches direction from stick
-  float yaw = pid_yaw.execute(instructions->input4, curr_sf.yawRate);
-  float throttle = instructions->input3;  //
+    PIDController pid_pitch{pitch_kp, pitch_ki, pitch_kd, max_i_windup, -pid_abs_max, pid_abs_max};
 
-  // mix the PID's.
-  PID_Out.backLeftMotorPercent   = throttle - roll - pitch - yaw;
-  PID_Out.frontLeftMotorPercent  = throttle - roll + pitch + yaw;
-  PID_Out.backRightMotorPercent  = throttle + roll - pitch + yaw;
-  PID_Out.frontRightMotorPercent = throttle + roll + pitch - yaw;
+    PIDController pid_yaw{yaw_kp, yaw_ki, yaw_kd, max_i_windup, -pid_abs_max, pid_abs_max};
+
+    // get PID result
+    float roll = pid_roll.execute(instructions->input1, curr_sf.roll, curr_sf.rollRate);
+    float pitch = pid_pitch.execute(instructions->input2, curr_sf.pitch, curr_sf.pitchRate);
+
+    // yaw is now going to target a specific yawrate.
+    // FIXME: double check that the yawRate matches direction from stick
+    float yaw = pid_yaw.execute(instructions->input4, curr_sf.yawRate);
+    float throttle = instructions->input3;  //
+
+    // mix the PID's.
+    PID_Out.backLeftMotorPercent = throttle - roll - pitch - yaw;
+    PID_Out.frontLeftMotorPercent = throttle - roll + pitch + yaw;
+    PID_Out.backRightMotorPercent = throttle + roll - pitch + yaw;
+    PID_Out.frontRightMotorPercent = throttle + roll + pitch - yaw;
+  } else {
+    if (prev_PID_Method != PID_method) {
+      // we have just toggled the PID method, so save height location
+      prev_sf = curr_sf;  // not sure about the pointer operation...
+    }
+    // hold altitude
+    const float roll_kp = 0.05;
+    const float roll_ki = 0;
+    const float roll_kd = 0.05;
+
+    const float pitch_kp = 0.05;
+    const float pitch_ki = 0;
+    const float pitch_kd = 0.05;
+
+    const float yaw_kp = 0.25;
+    const float yaw_ki = 0;
+    const float yaw_kd = 0.05;
+
+    const float alt_kp = 0.025;
+    const float alt_ki = 0;
+    const float alt_kd = 0.0125;
+
+    PIDController pid_roll(roll_kp, roll_ki, roll_kd, max_i_windup, -pid_abs_max, pid_abs_max);
+
+    PIDController pid_pitch(pitch_kp, pitch_ki, pitch_kd, max_i_windup, -pid_abs_max, pid_abs_max);
+
+    PIDController pid_yaw(yaw_kp, yaw_ki, yaw_kd, max_i_windup, -pid_abs_max, pid_abs_max);
+
+    PIDController pid_altitude(alt_kp, alt_ki, alt_kd, max_i_windup, -pid_abs_max, pid_abs_max);
+
+    // get PID result
+    float roll = pid_roll.execute(instructions->input1, curr_sf.roll, curr_sf.rollRate);
+    float pitch = pid_pitch.execute(instructions->input2, curr_sf.pitch, curr_sf.pitchRate);
+
+    // yaw is now going to target a specific yawrate.
+    // FIXME: double check that the yawRate matches direction from stick
+    float yaw = pid_yaw.execute(instructions->input4, curr_sf.yawRate);
+    float throttle = pid_altitude.execute(prev_sf.altitude, curr_sf.altitude);  // desired is the one assigned on toggle
+
+    // mix the PID's.
+    PID_Out.backLeftMotorPercent = throttle - roll - pitch - yaw;
+    PID_Out.frontLeftMotorPercent = throttle - roll + pitch + yaw;
+    PID_Out.backRightMotorPercent = throttle + roll - pitch + yaw;
+    PID_Out.frontRightMotorPercent = throttle + roll + pitch - yaw;
+  }
   return &PID_Out;
 }


### PR DESCRIPTION
# Description

Patch to add PID modes for holding altitude and hovering in place.

This operates on the principle that when a switch is toggled or command otherwise set, the drone will hover in at the altitude / state that it is in when the toggle occurs.


## Altitude Hold
- On Toggle, the current altitude is saved and the drone will attempt to maintain that altitude.
- Throttle stick is de-activated and there is currently no way to adjust the height of the drone in this state. Looking for ideas.
- Uses current roll/pitch corrections to maintain position.
- Will maintain yawRate of 0, which should be equal to minimal change in yaw.

## Position Hold
- On toggle, current position is saved and drone will attempt to maintain current latitude, longitude, altitude, and heading.
- Do we want to re-map controls inputs to move the position around? Perhaps just with slew control so that fine adjustments in positioning are easier?
- Currently does not interface with any gps data, subject to imu drift.
- Uses same yaw, altitude PID as altitude hold.
- Uses 2 new PID's for latitude and longitude. Each PID is driven off a difference in location from current and target, and will compensate the 2 sets of motors in opposite directions to return to the position.

Include the Asana link, or relevant issue. 
Best thing I can do is link to the discord, was a quick patch.

https://discord.com/channels/776618956638388305/895818568065757184/969037598871937054

## Testing

Safety builds. Will need to be tested on drone.

Builds of existing PID tuned code.

## Documentation

# Merge Checklist:

- [ ] The changes have been well commented, particularly in hard-to-understand areas.
- [ ] The code has been tested on hardware, either by me or somone else.
- [ ] Comprehensive unit tests have been made for this change
- [x] Corresponding changes to documentation have been created and links to this documentation are provided within the pull request.
- [x] The changes generate no new warnings and compile and run; A screenshot of a successful compile message is attached to the bottom of this PR.

Screenshot:
-------
![image](https://user-images.githubusercontent.com/45152791/165659259-e3b3e726-e7ab-4d87-9695-5ad3591f7975.png)

