### PR TITLE
Add MOE Bit disable for Motor Outputs in Hardfault

### DIFF
--- a/Safety/boardfiles/Src/stm32f0xx_it.c
+++ b/Safety/boardfiles/Src/stm32f0xx_it.c
@@ -42,6 +42,8 @@
 /* External variables --------------------------------------------------------*/
 extern SPI_HandleTypeDef hspi1;
 extern TIM_HandleTypeDef htim15;
+extern TIM_HandleTypeDef htim1;
+extern TIM_HandleTypeDef htim3;
 
 /******************************************************************************/
 /*            Cortex-M0 Processor Interruption and Exception Handlers         */
@@ -66,7 +68,10 @@ void NMI_Handler(void)
 void HardFault_Handler(void)
 {
   /* USER CODE BEGIN HardFault_IRQn 0 */
-
+  // Shut down outputs here
+  __HAL_TIM_MOE_DISABLE(&htim1);
+  __HAL_TIM_MOE_DISABLE(&htim3);
+  
   /* USER CODE END HardFault_IRQn 0 */
   while (1)
   {


### PR DESCRIPTION
# Description

Add MOE (Main Output Enable) bit disable into hardfault handler for tim1 and tim3 that control motors.

https://uwarg-docs.atlassian.net/wiki/spaces/ZP/pages/2064286344/Hardfault+Shutdown

## Testing

Requires test on hardware by initiating a hardfault while motors are enabled.

## Documentation

https://uwarg-docs.atlassian.net/wiki/spaces/ZP/pages/2064286344/Hardfault+Shutdown

# Merge Checklist:

- [x] The changes have been well commented, particularly in hard-to-understand areas.
- [ ] The code has been tested on hardware, either by me or someone else.
- [ ] Comprehensive unit tests have been made for this change
- [x] Corresponding changes to documentation have been created and links to this documentation are provided within the pull request.
- [x] The changes generate no new warnings and compile and run; A screenshot of a successful compile message is attached to the bottom of this PR.
